### PR TITLE
Update test_notebooks filter that uses 11.6 schema

### DIFF
--- a/nmdc_api_utilities/test/test_biosample.py
+++ b/nmdc_api_utilities/test/test_biosample.py
@@ -5,29 +5,34 @@ from nmdc_api_utilities.data_processing import DataProcessing
 import logging
 
 logging.basicConfig(level=logging.DEBUG)
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+ENV = os.getenv("ENV")
 
 
 def test_find_biosample_by_id():
-    biosample = BiosampleSearch()
+    biosample = BiosampleSearch(env=ENV)
     results = biosample.get_record_by_id("nmdc:bsm-11-002vgm56")
     assert len(results) > 0
     assert results["id"] == "nmdc:bsm-11-002vgm56"
 
 
 def test_logger():
-    biosample = BiosampleSearch()
+    biosample = BiosampleSearch(env=ENV)
     logging.basicConfig(level=logging.DEBUG)
     results = biosample.get_record_by_id("nmdc:bsm-11-002vgm56")
 
 
 def test_biosample_by_filter():
-    biosample = BiosampleSearch()
+    biosample = BiosampleSearch(env=ENV)
     results = biosample.get_record_by_filter('{"id":"nmdc:bsm-11-006pnx90"}')
     assert len(results) > 0
 
 
 def test_biosample_by_attribute():
-    biosample = BiosampleSearch()
+    biosample = BiosampleSearch(env=ENV)
     results = biosample.get_record_by_attribute(
         "id", "nmdc:bsm-11-006pnx90", exact_match=False
     )
@@ -37,7 +42,7 @@ def test_biosample_by_attribute():
 
 def test_biosample_by_latitude():
     # {"lat_lon.latitude": {"$gt": 45.0}, "lat_lon.longitude": {"$lt":45}}
-    biosample = BiosampleSearch()
+    biosample = BiosampleSearch(env=ENV)
     results = biosample.get_record_by_latitude("gt", 45.0)
     assert len(results) > 0
     assert results[0]["lat_lon"]["latitude"] == 63.875088
@@ -45,7 +50,7 @@ def test_biosample_by_latitude():
 
 def test_biosample_by_longitude():
     # {"lat_lon.latitude": {"$gt": 45.0}, "lat_lon.longitude": {"$lt":45}}
-    biosample = BiosampleSearch()
+    biosample = BiosampleSearch(env=ENV)
     results = biosample.get_record_by_longitude("lt", 45.0)
     assert len(results) > 0
     assert results[0]["lat_lon"]["longitude"] == -149.210438
@@ -53,7 +58,7 @@ def test_biosample_by_longitude():
 
 def test_biosample_by_lat_long():
     # {"lat_lon.latitude": {"$gt": 45.0}, "lat_lon.longitude": {"$lt":45}}
-    biosample = BiosampleSearch()
+    biosample = BiosampleSearch(env=ENV)
     results = biosample.get_record_by_lat_long("gt", "lt", 45.0, 45.0)
     assert len(results) > 0
     assert results[0]["lat_lon"]["latitude"] == 63.875088
@@ -62,7 +67,7 @@ def test_biosample_by_lat_long():
 
 def test_biosample_build_filter_1():
     u = DataProcessing()
-    b = BiosampleSearch()
+    b = BiosampleSearch(env=ENV)
     filter = u.build_filter({"name": "G6R2_NF_20JUN2016"})
     results = b.get_record_by_filter(filter)
     print(results)
@@ -71,7 +76,7 @@ def test_biosample_build_filter_1():
 
 def test_biosample_build_filter_2():
     u = DataProcessing()
-    b = BiosampleSearch()
+    b = BiosampleSearch(env=ENV)
     filter = u.build_filter({"name": "G6R2_NF_20JUN2016", "id": "nmdc:bsm-11-006pnx90"})
     logging.debug("Biosample test filter:", filter)
     results = b.get_record_by_filter(filter)

--- a/nmdc_api_utilities/test/test_metdata.py
+++ b/nmdc_api_utilities/test/test_metdata.py
@@ -7,9 +7,10 @@ load_dotenv()
 
 CLIENT_ID = os.getenv("CLIENT_ID")
 CLIENT_SECRET = os.getenv("CLIENT_SECRET")
+ENV = os.getenv("ENV")
 
 
 def test_validate():
-    metadata = Metadata()
+    metadata = Metadata(env=ENV)
     results = metadata.validate_json("nmdc_api_utilities/test/test_data/test.json")
     assert results == None

--- a/nmdc_api_utilities/test/test_mint.py
+++ b/nmdc_api_utilities/test/test_mint.py
@@ -5,13 +5,13 @@ import os
 from dotenv import load_dotenv
 
 load_dotenv()
-
+ENV = os.getenv("ENV")
 CLIENT_ID = os.getenv("CLIENT_ID")
 CLIENT_SECRET = os.getenv("CLIENT_SECRET")
 
 
 def test_mint():
-    mint = Minter()
+    mint = Minter(env=ENV)
     results = mint.mint("nmdc:DataObject", CLIENT_ID, CLIENT_SECRET)
     assert results
     assert "nmdc:dobj" in results

--- a/nmdc_api_utilities/test/test_notebooks.py
+++ b/nmdc_api_utilities/test/test_notebooks.py
@@ -2,15 +2,20 @@
 from nmdc_api_utilities.data_processing import DataProcessing
 from nmdc_api_utilities.data_object_search import DataObjectSearch
 from nmdc_api_utilities.workflow_execution_search import WorkflowExecutionSearch
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+ENV = os.getenv("ENV")
 
 
 def test_nom_notebook():
-    dos_client = DataObjectSearch()
+    dos_client = DataObjectSearch(env=ENV)
 
     dp_client = DataProcessing()
     processed_nom = dos_client.get_record_by_attribute(
         attribute_name="data_object_type",
-        attribute_value="FT ICR-MS Analysis Results",
+        attribute_value="Direct Infusion FT-ICR MS Analysis Results",
         max_page_size=100,
         fields="id,md5_checksum,url",
         all_pages=True,

--- a/nmdc_api_utilities/test/test_study.py
+++ b/nmdc_api_utilities/test/test_study.py
@@ -1,12 +1,16 @@
 # -*- coding: utf-8 -*-
 from nmdc_api_utilities.study_search import StudySearch
 import logging
+import os
+from dotenv import load_dotenv
 
+load_dotenv()
+ENV = os.getenv("ENV")
 logging.basicConfig(level=logging.DEBUG)
 
 
 def test_find_study_by_attribute():
-    st = StudySearch()
+    st = StudySearch(env=ENV)
     stu = st.get_record_by_attribute(
         "name",
         "Lab enrichment of tropical soil microbial communities from Luquillo Experimental Forest, Puerto Rico",
@@ -20,14 +24,14 @@ def test_find_study_by_attribute():
 
 
 def test_find_study_by_id():
-    st = StudySearch()
+    st = StudySearch(env=ENV)
     stu = st.get_record_by_id("nmdc:sty-11-8fb6t785")
     assert len(stu) > 0
     assert stu["id"] == "nmdc:sty-11-8fb6t785"
 
 
 def test_find_study_by_filter():
-    st = StudySearch()
+    st = StudySearch(env=ENV)
     stu = st.get_record_by_filter(
         '{"name":"Lab enrichment of tropical soil microbial communities from Luquillo Experimental Forest, Puerto Rico"}'
     )
@@ -39,14 +43,14 @@ def test_find_study_by_filter():
 
 
 def test_get_studies_all_pages():
-    st = StudySearch()
+    st = StudySearch(env=ENV)
     studies = st.get_records(max_page_size=20, all_pages=True)
     print(studies)
     assert len(studies) > 32
 
 
 def test_get_studies():
-    st = StudySearch()
+    st = StudySearch(env=ENV)
     studies = st.get_records(max_page_size=100)
     print(studies)
     assert len(studies) > 32

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "nmdc_api_utilities"
 
-version = "0.3.8"
+version = "0.3.9"
 
 description = "A Python library for general research functions using NMDC APIs"
 authors = [


### PR DESCRIPTION
One of the tests was filtering on an old data_object_type that was updated in the 11.7 release. I updated the type. Additionally, I updated the tests that were not properly using the environment variable to test dev vs prod. 